### PR TITLE
refact(AngularJS UI): Removed obsolete code, more one time bindings, switched on production mode

### DIFF
--- a/AngularJS/examples/angularjs-perf-test/src/components/ticker-list/price.ts
+++ b/AngularJS/examples/angularjs-perf-test/src/components/ticker-list/price.ts
@@ -15,17 +15,13 @@ class PriceController implements IPriceController  {
     private $scope: ng.IScope,
     private $timeout: ng.ITimeoutService) {
 
-    const detachPriceChangeListener = this.$scope.$watch("$ctrl.price", (newValue, oldValue) => {
+    this.$scope.$watch(() => this.price, (newValue, oldValue) => {
         if (newValue !== oldValue) {
           this.priceChanged = true;
           this.$timeout(() => {
             this.priceChanged = false;
           }, 100);
         }
-    });
-
-    this.$scope.$on('$destroy', () => {
-        detachPriceChangeListener();
     });
   }
 }

--- a/AngularJS/examples/angularjs-perf-test/src/components/ticker-list/sector-name.html
+++ b/AngularJS/examples/angularjs-perf-test/src/components/ticker-list/sector-name.html
@@ -1,3 +1,1 @@
-<section class="sector">
-  <div>{{::$ctrl.name}}</div>
-</section>
+<section class="sector">{{::$ctrl.name}}</section>

--- a/AngularJS/examples/angularjs-perf-test/src/components/ticker-list/sma.html
+++ b/AngularJS/examples/angularjs-perf-test/src/components/ticker-list/sma.html
@@ -1,3 +1,1 @@
-<div class="sma" ng-class="$ctrl.smaChanged ? 'sma-changed' : ''">
-  {{::$ctrl.label}}:&nbsp;{{$ctrl.value.toFixed(2)}}
-</div>
+<div class="sma">{{::$ctrl.label}}:&nbsp;{{::$ctrl.value.toFixed(2)}}</div>

--- a/AngularJS/examples/angularjs-perf-test/src/components/ticker-list/sma.ts
+++ b/AngularJS/examples/angularjs-perf-test/src/components/ticker-list/sma.ts
@@ -11,22 +11,7 @@ class SmaController implements ISmaController  {
   label: string;
   value: number;
 
-  constructor(
-    private $scope: ng.IScope,
-    private $timeout: ng.ITimeoutService) {
-
-    const detachSmaChangeListener = this.$scope.$watch("$ctrl.sma", (newValue, oldValue) => {
-      if (newValue !== oldValue) {
-        this.smaChanged = true;
-        this.$timeout(() => {
-          this.smaChanged = false;
-        }, 100);
-      }
-    });
-
-    this.$scope.$on('$destroy', () => {
-      detachSmaChangeListener();
-    });
+  constructor() {
   }
 }
 

--- a/AngularJS/examples/angularjs-perf-test/src/components/ticker-list/ticker-list.html
+++ b/AngularJS/examples/angularjs-perf-test/src/components/ticker-list/ticker-list.html
@@ -1,3 +1,3 @@
 <section class="ticker-list">
-  <ticker-tile ticker-data="tickerData" ng-repeat="(ticker, tickerData) in $ctrl.getTickerHash() track by ticker"></ticker-tile>
+  <ticker-tile ticker-data="$ctrl.getTickerData(ticker)" ng-repeat="ticker in $ctrl.getTickerList() track by ticker"></ticker-tile>
 </section>

--- a/AngularJS/examples/angularjs-perf-test/src/components/ticker-list/ticker-list.ts
+++ b/AngularJS/examples/angularjs-perf-test/src/components/ticker-list/ticker-list.ts
@@ -1,17 +1,22 @@
-import {ITickerHash, ITickerDataService} from '../../services/tickerDataService';
+import {ITickerHash, ITickerDataService, ITickerData} from '../../services/tickerDataService';
 
 import * as html from './ticker-list.html';
 
 export interface ITickerListController {
-  getTickerHash(): ITickerHash;
+    getTickerList(): string [];
+    getTickerData(ticker): ITickerData;
 };
 
 class TickerListController implements ITickerListController  {
   constructor(private tickerDataService: ITickerDataService) {
   }
 
-  getTickerHash(): ITickerHash {
-    return this.tickerDataService.tickerHash;
+  getTickerList(): string[] {
+      return this.tickerDataService.tickerList;
+  }
+
+  getTickerData(ticker): ITickerData {
+      return this.tickerDataService.tickerHash[ticker];
   }
 }
 

--- a/AngularJS/examples/angularjs-perf-test/src/components/ticker-list/ticker-tile.html
+++ b/AngularJS/examples/angularjs-perf-test/src/components/ticker-list/ticker-tile.html
@@ -1,10 +1,10 @@
 <section class="ticker-tile">
   <h1 class="ticker" title={{::$ctrl.tickerData.company}} 
-      ng-class="$ctrl.tickerData.change >= 0 ? 'up' : 'down'">{{$ctrl.tickerData.ticker}}</h1>
+      ng-class="$ctrl.tickerData.change >= 0 ? 'up' : 'down'">{{::$ctrl.tickerData.ticker}}</h1>
   <sector-name name="::$ctrl.tickerData.sector"></sector-name>
   <price price="$ctrl.tickerData.price" change="$ctrl.tickerData.change"></price>
   <volume volume="$ctrl.tickerData.volume"></volume>
-  <sma class="sma" label="sma20" value="$ctrl.tickerData.sma20"></sma>
-  <sma class="sma" label="sma50" value="$ctrl.tickerData.sma50"></sma>
-  <sma class="sma" label="sma200" value="$ctrl.tickerData.sma200"></sma>
+  <sma class="sma" label="sma20" value="::$ctrl.tickerData.sma20"></sma>
+  <sma class="sma" label="sma50" value="::$ctrl.tickerData.sma50"></sma>
+  <sma class="sma" label="sma200" value="::$ctrl.tickerData.sma200"></sma>
 </section>

--- a/AngularJS/examples/angularjs-perf-test/src/components/ticker-list/volume.ts
+++ b/AngularJS/examples/angularjs-perf-test/src/components/ticker-list/volume.ts
@@ -12,17 +12,13 @@ class VolumeController implements IVolumeController  {
   constructor(private $scope: ng.IScope,
     private $timeout: ng.ITimeoutService) {
 
-    const detachVolumeChangeListener = this.$scope.$watch("$ctrl.volume", (newValue, oldValue) => {
+    this.$scope.$watch(() => this.volume, (newValue, oldValue) => {
         if (newValue !== oldValue) {
           this.volumeChanged = true;
           this.$timeout(() => {
             this.volumeChanged = false;
           }, 100);
         }
-    });
-
-    this.$scope.$on('$destroy', () => {
-        detachVolumeChangeListener();
     });
   }
 }

--- a/AngularJS/examples/angularjs-perf-test/src/index.ts
+++ b/AngularJS/examples/angularjs-perf-test/src/index.ts
@@ -7,9 +7,11 @@ require('angular-sanitize');
 import * as html from './components/app.html';
 
 angular.module('perfTest', ['ngRoute', 'ngSanitize', 'ngAnimate'])
-  .config(['$routeProvider', '$sceDelegateProvider',
-
-  function($routeProvider, $sceDelegateProvider) {
+  .config(['$routeProvider', '$sceDelegateProvider', '$compileProvider',
+  function($routeProvider, $sceDelegateProvider, $compileProvider) {
+    $compileProvider.debugInfoEnabled(false);
+    $compileProvider.commentDirectivesEnabled(false);
+    $compileProvider.cssClassDirectivesEnabled(false);
 
     $sceDelegateProvider.resourceUrlWhitelist(['**']);
 

--- a/AngularJS/examples/angularjs-perf-test/src/services/serverDataManager.ts
+++ b/AngularJS/examples/angularjs-perf-test/src/services/serverDataManager.ts
@@ -21,15 +21,17 @@ export class ServerDataManager {
   }
 
   hasReachedEnd() : boolean {
-    return (this.newTickerIndexToAdd >= this.tickerDataFromServer.length - 1);
+    return this.newTickerIndexToAdd >= this.tickerDataFromServer.length - 1;
   }
 
   getNewTickers(count: number): ITickerData[] {
-    let newTickers: ITickerData[] = [];
+    const newTickers: ITickerData[] = [];
+
     _.times(count, () => {
-      if (this.newTickerIndexToAdd < this.tickerDataFromServer.length - 1) {
+      if (!this.hasReachedEnd()) {
         this.newTickerIndexToAdd++;
-        var tickerItem = this.tickerDataFromServer[this.newTickerIndexToAdd];
+        const tickerItem = this.tickerDataFromServer[this.newTickerIndexToAdd];
+
         newTickers.push({
           ticker: <string>tickerItem.Ticker,
           company: <string>tickerItem.Company,
@@ -45,6 +47,7 @@ export class ServerDataManager {
         });
       }
     });
+
     return newTickers;
   }
 }

--- a/AngularJS/examples/angularjs-perf-test/src/services/tickerDataService.ts
+++ b/AngularJS/examples/angularjs-perf-test/src/services/tickerDataService.ts
@@ -47,8 +47,8 @@ class TickerDataService implements ITickerDataService {
   }
 
   addTickers(tickerDataList: ITickerData[]): void {
-    _.each(tickerDataList, (tickerData: ITickerData) => {
-      if (!this.tickerHash[tickerData.ticker]) {
+    tickerDataList.forEach((tickerData: ITickerData) => {
+      if (!(tickerData.ticker in this.tickerHash)) {
         this.tickerList.push(tickerData.ticker);
         this.tickerHash[tickerData.ticker] = tickerData;
       }
@@ -56,8 +56,8 @@ class TickerDataService implements ITickerDataService {
   }
 
   deleteTickers(tickers: string[]): void {
-    _.each(tickers, (ticker: string) => {
-      if (this.tickerHash[ticker]) {
+    tickers.forEach((ticker: string) => {
+      if (ticker in this.tickerHash) {
         delete this.tickerHash[ticker];
         _.pull(this.tickerList, ticker);
       }
@@ -65,12 +65,12 @@ class TickerDataService implements ITickerDataService {
   }
 
   clearAllTickers(): void {
-    this.tickerList = [];
+    this.tickerList.length = 0;
     this.tickerHash = {};
   }
 
   updatePrice(ticker: string, price: number, change: number): void {
-    let tickerData: ITickerData = this.tickerHash[ticker];
+    const tickerData: ITickerData = this.tickerHash[ticker];
     if (tickerData) {
       tickerData.price = price;
       tickerData.change = change;
@@ -78,7 +78,7 @@ class TickerDataService implements ITickerDataService {
   }
 
   public updateVolume(ticker: string, volume: number): void {
-    let tickerData: ITickerData = this.tickerHash[ticker];
+    const tickerData: ITickerData = this.tickerHash[ticker];
     if (tickerData) {
       tickerData.volume = volume;
     }


### PR DESCRIPTION
About 30% improvement for updates on my machine.
For adding up to 5K tickers things go bad around 75K nodes rather then 55K.

All `$watch` detachers are removed due to the fact that AngularJS takes care of em.

Also `sma` component doesn't get any updates, hence doesn't need a watcher and can enjoy one time bindings as well.

For the `tickers-list` replaced hash with a list, but didn't notice any performance gains.

@guptag, let me know what do you think.